### PR TITLE
fix: react query 제거 및 react 훅 제거

### DIFF
--- a/src/components/test/TestResult/HashTag/HashTag.tsx
+++ b/src/components/test/TestResult/HashTag/HashTag.tsx
@@ -1,10 +1,9 @@
-import {Tag} from "./HashTag.styles";
+import { Tag } from "./HashTag.styles";
 
 interface HashTagProps {
-  text: string;
+  text: string | undefined;
 }
 
 export default function HashTag({ text }: HashTagProps) {
   return <Tag>#{text}</Tag>;
 }
-

--- a/src/components/test/TestResult/RelationType/RelationType.tsx
+++ b/src/components/test/TestResult/RelationType/RelationType.tsx
@@ -1,14 +1,26 @@
-import {Container, Title, GoodType, TypeTitle, Mbti, Contents, BadType } from "./RelationType.styles";
+import {
+  Container,
+  Title,
+  GoodType,
+  TypeTitle,
+  Mbti,
+  Contents,
+  BadType
+} from "./RelationType.styles";
 
 interface relation {
-  good: {
-    name: string;
-    description: string;
-  };
-  bad: {
-    name: string;
-    description: string;
-  };
+  good:
+    | undefined
+    | {
+        name: string | undefined;
+        description: string | undefined;
+      };
+  bad:
+    | undefined
+    | {
+        name: string | undefined;
+        description: string | undefined;
+      };
 }
 
 export default function RelationType({ good, bad }: relation) {
@@ -17,13 +29,13 @@ export default function RelationType({ good, bad }: relation) {
       <Title>유형별 관계성</Title>
       <GoodType>
         <TypeTitle>잘 어울리는 유형</TypeTitle>
-        <Mbti>❤️{good.name}❤️</Mbti>
-        <Contents>{good.description}</Contents>
+        <Mbti>❤️{good?.name}❤️</Mbti>
+        <Contents>{good?.description}</Contents>
       </GoodType>
       <BadType>
         <TypeTitle>친해지기 힘든 유형</TypeTitle>
-        <Mbti>❄️{bad.name}❄️</Mbti>
-        <Contents>{bad.description}</Contents>
+        <Mbti>❄️{bad?.name}❄️</Mbti>
+        <Contents>{bad?.description}</Contents>
       </BadType>
     </Container>
   );

--- a/src/components/test/loading/Loading.tsx
+++ b/src/components/test/loading/Loading.tsx
@@ -192,30 +192,9 @@ function Loading({ userResponse, visible }: UserResponseProps) {
       mbtiType: updatedUserResponse.mbtiType
     };
 
-    try {
-      mutation.mutateAsync(updatedUserResponse);
-      // const putResponse: UserResponseProps = await axiosRequest.requestAxios(
-      //   "put",
-      //   "/stats",
-      //   updatedUserResponse
-      // );
-
-      // // console.log("USERMBTI", userMBTI);
-      // const patchResponse = await axiosRequest.requestAxios(
-      //   "patch",
-      //   `/stats/${userMBTI}`
-      // );
-
-      // console.log(patchResponse, "🚀🚀🚀🚀🚀🚀patch 요청 response");
-      // console.log(putResponse, "🚀🚀🚀🚀🚀🚀put 요청 response");
-      // console.log("resultData", resultData);
-
-      // 결과페이지에 데이터 전송 ***********************************
-      const queryParams = new URLSearchParams({ mbti: resultData.mbtiType });
-      navigate("/result?" + queryParams.toString(), { state: { resultData } });
-    } catch (error) {
-      // console.error(error);
-    }
+    mutation.mutateAsync(updatedUserResponse);
+    const queryParams = new URLSearchParams({ mbti: resultData.mbtiType });
+    navigate("/result?" + queryParams.toString(), { state: { resultData } });
   };
 
   return visible ? (

--- a/src/pages/test/TestResult/TestResult.tsx
+++ b/src/pages/test/TestResult/TestResult.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 
 import axiosRequest from "@/api/index";
@@ -28,26 +27,6 @@ import { handleShareClick } from "@/components/common/ShareLink";
 import { useQuery } from "@tanstack/react-query";
 
 export default function TestResult() {
-  const [mbti, setMbti] = useState<ResMbti>({
-    _id: "",
-    name: "",
-    count: 0,
-    summary: "",
-    content: {
-      description: "",
-      good: {
-        name: "",
-        description: ""
-      },
-      bad: {
-        name: "",
-        description: ""
-      },
-      __v: 0
-    },
-    tag: []
-  });
-
   const location = useLocation();
   const searchParms = new URLSearchParams(location.search);
   const mbtiType: string | null = searchParms.get("mbti");
@@ -58,7 +37,11 @@ export default function TestResult() {
     ? location.state.resultData
     : null;
 
-  const { data, isLoading, isError } = useQuery({
+  const {
+    data: mbti,
+    isLoading,
+    isError
+  } = useQuery({
     queryKey: ["mbti", "mbtiType"],
     queryFn: () =>
       axiosRequest.requestAxios<ResData<ResMbti>>("get", `/mbti/${mbtiType}`),
@@ -67,23 +50,6 @@ export default function TestResult() {
     retry: 3
   });
 
-  useEffect(() => {
-    if (!isLoading && !isError && data) setMbti(data);
-    // const getMbti = async () => {
-    //   try {
-    //     const response: ResData<ResMbti> = await axiosRequest.requestAxios(
-    //       "get",
-    //       `/mbti/${mbtiType}`,
-    //       {}
-    //     );
-    //     setMbti(response.data);
-    //   } catch (e) {
-    //     console.error(e);
-    //   }
-    // };
-    // getMbti();
-  }, [data]);
-
   const handleShareButtonClick = () => {
     handleShareClick();
   };
@@ -91,7 +57,7 @@ export default function TestResult() {
   return (
     <Container style={{ backgroundColor: colorObj.out }}>
       <Header>
-        <Title>{mbti.name}</Title>
+        <Title>{mbti?.name}</Title>
         <ShareButton onClick={handleShareButtonClick}>
           결과 공유하기
         </ShareButton>
@@ -101,23 +67,20 @@ export default function TestResult() {
           <Character bgcolor={colorObj.in} gcolor={colorObj.out} />
           <ContentWrapper style={{ backgroundColor: colorObj.in }}>
             <ContentTitle>
-              {mbti.summary} {mbti.name}
+              {mbti?.summary} {mbti?.name}
             </ContentTitle>
-            <Content>{mbti.content?.description}</Content>
+            <Content>{mbti?.content?.description}</Content>
             <HashTags>
-              <HashTag text={mbti.tag[0]}></HashTag>
-              <HashTag text={mbti.tag[1]}></HashTag>
-              <HashTag text={mbti.tag[2]}></HashTag>
-              <HashTag text={mbti.tag[3]}></HashTag>
+              <HashTag text={mbti?.tag[0]}></HashTag>
+              <HashTag text={mbti?.tag[1]}></HashTag>
+              <HashTag text={mbti?.tag[2]}></HashTag>
+              <HashTag text={mbti?.tag[3]}></HashTag>
             </HashTags>
           </ContentWrapper>
         </MainTop>
         <MainBottom style={{ backgroundColor: colorObj.out }}>
           {resultData && <TypePercentageBars result={resultData} />}
-          <RelationType
-            good={mbti.content?.good ?? ""}
-            bad={mbti.content?.bad ?? ""}
-          />
+          <RelationType good={mbti?.content?.good} bad={mbti?.content?.bad} />
         </MainBottom>
       </Main>
       <Buttons>


### PR DESCRIPTION
> 변경사항

- react 훅 제거
- testResult에서 사용되는 타입 수정

> 변경사유

- react-query를 사용하기 때문에 react 훅인 useState, useEffect 훅은 사용할 필요가 없다.
- react query 형식에 맞추기 위해 타입을 일부 수정하였다. (undefined 추가)