### PR TITLE
fix: twinmacro 제거, tw-styled-components 추가

### DIFF
--- a/src/components/layout/Header/Header.styles.ts
+++ b/src/components/layout/Header/Header.styles.ts
@@ -1,10 +1,12 @@
-import tw from "twin.macro";
+// import tw from "twin.macro";
+import tw from "tailwind-styled-components";
 import { BsList } from "react-icons/bs";
-export const ScaledBsList = tw(BsList)`
 
+export const ScaledBsList = tw(BsList)`
 text-4xl
 text-black
 `;
+
 export const Header = tw.header`
   flex
   flex-wrap


### PR DESCRIPTION
twin.macro 적용 시 daisyui의 drawer 기능이 정상 작동하지 않는 이슈 발생

따라서 기존에 적용하였던 tailwind-styled-components를 추가하여 임시로 이슈 해결